### PR TITLE
Fix a typo in the Spider scripts

### DIFF
--- a/src/main/resources/scripts/spider.json
+++ b/src/main/resources/scripts/spider.json
@@ -322,7 +322,7 @@
                 "gloomyTextType": "ACTION"
               },
               "failureResponses": {
-                "upbeat": "The spider's shaking something up! It's readying to attack!'",
+                "upbeat": "The spider's shaking something up! It's readying to attack!",
                 "timid": "It's lost interest in negotiation!",
                 "irritable": "That's riled it up!",
                 "gloomy": "It's lost the will to continue on!",


### PR DESCRIPTION
Minor tweak to correct an erroneous quote in one line of the Spider's scripts